### PR TITLE
プラグインのインストールボタンの表示が正しくない場合がある不具合の修正

### DIFF
--- a/utils.rb
+++ b/utils.rb
@@ -14,7 +14,8 @@ module Plugin::Mikustore
     # ==== Return
     # インストールされているプラグインのバージョン
     def installed_version(slug, unspecified_case="", notfound_case=nil)
-      if(Plugin.plugin_list.include?(slug))
+      plugin_dir = ENV["HOME"] + "/.mikutter/plugin/#{slug}/"
+      if(File.directory?(plugin_dir) && Plugin.plugin_list.include?(slug))
         plugin = Plugin.__send__(:create, slug)
         if defined? plugin.spec[:version]
           return plugin.spec[:version]


### PR DESCRIPTION
起動中にプラグインのディレクトリが消失すると表示が「インストール済み」のままで、再起動するまで反映されないっぽいです

なので、プラグインのインストールチェックの時にディレクトリの存在もチェックするとよろしいんじゃないでしょうか
